### PR TITLE
Include original item, index in dispatched "select" event #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm i -D svelte-typeahead
 
 ### Styling
 
-**Note:** this component is unstyled by design. You can target the component using the `[data-svelte-typeahead]` selector.
+**Note:** this component is minimally styled by design. You can target the component using the `[data-svelte-typeahead]` selector.
 
 ```css
 :global([data-svelte-typeahead]) {
@@ -97,6 +97,9 @@ Use a slot to render custom results.
 
 ### Dispatched events
 
+- **on:select**: dispatched when selecting a result
+- **on:clear**: dispatched when clearing the input field
+
 <!-- prettier-ignore-start -->
 ```svelte
 <script>
@@ -120,7 +123,9 @@ Use a slot to render custom results.
 
 <ul>
   {#each events as event}
-    <li>{event}</li>
+    <li>
+      <pre>{event}</pre>
+    </li>
   {/each}
 </ul>
 ```

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -2,7 +2,7 @@
   /**
    * @typedef {string | number | Record<string, any>} Item
    * @typedef {{ original: Item; index: number; score: number; string: string; }} FuzzyResult
-   * @event {{ selectedIndex: number; selected: Item; }} select
+   * @event {{ selectedIndex: number; selected: Item; original: Item; originalIndex: number; }} select
    * @event {any} clear
    * @slot {{ result: FuzzyResult; index: number }}
    */
@@ -50,10 +50,21 @@
   });
 
   async function select() {
-    value = extract(results[selectedIndex].original);
-    dispatch("select", { selectedIndex, selected: value });
+    const result = results[selectedIndex];
+
+    value = extract(result.original);
+
+    dispatch("select", {
+      selectedIndex,
+      selected: value,
+      original: result.original,
+      originalIndex: result.index,
+    });
+
     await tick();
+
     if (focusAfterSelect) searchRef.focus();
+
     hideDropdown = true;
   }
 
@@ -63,6 +74,101 @@
     .filter(({ score }) => score > 0);
   $: resultsId = results.map((result) => extract(result.original)).join("");
 </script>
+
+<svelte:window
+  on:click={({ target }) => {
+    if (!hideDropdown && results.length > 0 && comboboxRef && !comboboxRef.contains(target)) {
+      hideDropdown = true;
+    }
+  }}
+/>
+
+<div
+  data-svelte-typeahead
+  bind:this={comboboxRef}
+  role="combobox"
+  aria-haspopup="listbox"
+  aria-owns="{id}-listbox"
+  class:dropdown={results.length > 0}
+  aria-expanded={!hideDropdown && results.length > 0}
+  {id}
+>
+  <Search
+    {...$$restProps}
+    bind:this={searchRef}
+    aria-autocomplete="list"
+    aria-controls="{id}-listbox"
+    aria-labelledby="{id}-label"
+    aria-activedescendant=""
+    {id}
+    bind:value
+    on:type
+    on:input
+    on:change
+    on:focus
+    on:focus={() => {
+      hideDropdown = false;
+    }}
+    on:clear
+    on:clear={() => {
+      hideDropdown = false;
+    }}
+    on:blur
+    on:keydown
+    on:keydown={(e) => {
+      switch (e.key) {
+        case 'Enter':
+          select();
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          selectedIndex += 1;
+          if (selectedIndex === results.length) {
+            selectedIndex = 0;
+          }
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          selectedIndex -= 1;
+          if (selectedIndex < 0) {
+            selectedIndex = results.length - 1;
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          value = '';
+          searchRef.focus();
+          hideDropdown = true;
+          break;
+      }
+    }}
+  />
+  {#if !hideDropdown && results.length > 0}
+    <ul
+      class:svelte-typeahead-list={true}
+      role="listbox"
+      aria-labelledby=""
+      id="{id}-listbox"
+    >
+      {#each results as result, i}
+        <li
+          role="option"
+          id="{id}-result"
+          class:selected={selectedIndex === i}
+          aria-selected={selectedIndex === i}
+          on:click={() => {
+            selectedIndex = i;
+            select();
+          }}
+        >
+          <slot {result} index={i}>
+            {@html result.string}
+          </slot>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
 
 <style>
   [data-svelte-typeahead] {
@@ -124,93 +230,3 @@
     outline-width: 1px;
   }
 </style>
-
-<svelte:window
-  on:click={({ target }) => {
-    if (!hideDropdown && results.length > 0 && comboboxRef && !comboboxRef.contains(target)) {
-      hideDropdown = true;
-    }
-  }} />
-
-<div
-  data-svelte-typeahead
-  bind:this={comboboxRef}
-  role="combobox"
-  aria-haspopup="listbox"
-  aria-owns="{id}-listbox"
-  class:dropdown={results.length > 0}
-  aria-expanded={!hideDropdown && results.length > 0}
-  {id}>
-  <Search
-    {...$$restProps}
-    bind:this={searchRef}
-    aria-autocomplete="list"
-    aria-controls="{id}-listbox"
-    aria-labelledby="{id}-label"
-    aria-activedescendant=""
-    {id}
-    bind:value
-    on:type
-    on:input
-    on:change
-    on:focus
-    on:focus={() => {
-      hideDropdown = false;
-    }}
-    on:clear
-    on:clear={() => {
-      hideDropdown = false;
-    }}
-    on:blur
-    on:keydown
-    on:keydown={(e) => {
-      switch (e.key) {
-        case 'Enter':
-          select();
-          break;
-        case 'ArrowDown':
-          e.preventDefault();
-          selectedIndex += 1;
-          if (selectedIndex === results.length) {
-            selectedIndex = 0;
-          }
-          break;
-        case 'ArrowUp':
-          e.preventDefault();
-          selectedIndex -= 1;
-          if (selectedIndex < 0) {
-            selectedIndex = results.length - 1;
-          }
-          break;
-        case 'Escape':
-          e.preventDefault();
-          value = '';
-          searchRef.focus();
-          hideDropdown = true;
-          break;
-      }
-    }} />
-  {#if !hideDropdown && results.length > 0}
-    <ul
-      class:svelte-typeahead-list={true}
-      role="listbox"
-      aria-labelledby=""
-      id="{id}-listbox">
-      {#each results as result, i}
-        <li
-          role="option"
-          id="{id}-result"
-          class:selected={selectedIndex === i}
-          aria-selected={selectedIndex === i}
-          on:click={() => {
-            selectedIndex = i;
-            select();
-          }}>
-          <slot {result} index={i}>
-            {@html result.string}
-          </slot>
-        </li>
-      {/each}
-    </ul>
-  {/if}
-</div>

--- a/types/Typeahead.d.ts
+++ b/types/Typeahead.d.ts
@@ -56,6 +56,8 @@ export default class Typeahead extends SvelteComponentTyped<
     select: CustomEvent<{
       selectedIndex: number;
       selected: Item;
+      original: Item;
+      originalIndex: number;
     }>;
     type: CustomEvent<string>;
     clear: CustomEvent<any>;


### PR DESCRIPTION
Usage:

```svelte
<Typeahead
  on:select="{(e) => {
    console.log(e.detail.original);
    console.log(e.detail.originalIndex);
  }}"
/>
```