### PR TITLE
Option for keeping the searched value

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -20,6 +20,7 @@
   export let autoselect = true;
   
   /** Set to `keep` to keep the search field unchanged after select, set to `clear` to auto-clear search field */
+  /** @type {"update" | "clear" | "keep"} */
   export let inputAfterSelect = 'update';
 
   /** @type {FuzzyResult[]} */

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -18,6 +18,9 @@
 
   /** Set to `false` to prevent the first result from being selected */
   export let autoselect = true;
+  
+  /** Set to `keep` to keep the search field unchanged after select, set to `clear` to auto-clear search field */
+  export let inputAfterSelect = 'update';
 
   /** @type {FuzzyResult[]} */
   export let results = [];
@@ -51,8 +54,10 @@
 
   async function select() {
     const result = results[selectedIndex];
-
-    value = extract(result.original);
+    
+    const selectedValue = extract(result.original);
+    if (inputAfterSelect == 'clear') value = '';
+    if (inputAfterSelect == 'update') value = selectedValue;
 
     dispatch("select", {
       selectedIndex,

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -55,14 +55,15 @@
 
   async function select() {
     const result = results[selectedIndex];
-    
     const selectedValue = extract(result.original);
+    const searchedValue = value;
+    
     if (inputAfterSelect == 'clear') value = '';
     if (inputAfterSelect == 'update') value = selectedValue;
 
     dispatch("select", {
       selectedIndex,
-      searched: value,
+      searched: searchedValue,
       selected: selectedValue,
       original: result.original,
       originalIndex: result.index,

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -61,7 +61,8 @@
 
     dispatch("select", {
       selectedIndex,
-      selected: value,
+      searched: value,
+      selected: selectedValue,
       original: result.original,
       originalIndex: result.index,
     });


### PR DESCRIPTION
I want to search for multiple entries and only need the select events.

The update of the input field is bad for an continuus search, since the search result would be limited to the selected item.
Therefore I added the options to clear the search after an selection or to just keep the input.

E.g.
Searching for `C` and selecting `California` can now keep `C` as search string and the user can easily add `North Carolina` without having the remove characters from the search bar. Works great with `focusAfterSelect=true`.

Im very bad at naming things, so maybe there might be better ways to do that.