### PR TITLE
Filter items and disable items

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,33 +87,31 @@ Use a slot to render custom results.
 
 Use the `filter` to filter Items out and `disable` to disable them in the result set.
 
-Example for disabling and filtering items by their Title lenght:
+Example for disabling and filtering items by their title length:
 
 <!-- prettier-ignore-start -->
 ```svelte
 <script>
-    const extract = (item) => item.titel;
-    const disable = (item) => item.title.length > 4;
-    const filter = (item) => item.title.length > 8;
+    const disable = (item) => item.state.length > 4;
+    const filter = (item) => item.state.length > 8;
 </script>
-<Typeahead {data} {extract} {disable} {filter}>
+
+<Typeahead {data} extract={(item) => item.state} {disable} {filter} />
 ```
 <!-- prettier-ignore-end -->
 
 Example for disabling items after selecting them:
+
 <!-- prettier-ignore-start -->
 ```svelte
 <script>
-   function handleSelect(e) {  
-        let i = e.detail.originalIndex;
-        data[i].selected = true;
-    }
-    
-    const extract = (item) => item.titel;
-    const disable = (item) => item.selected;
+  function handleSelect(e) {  
+    let i = e.detail.originalIndex;
+    data[i].selected = true;
+  }
 </script>
 
-<Typeahead {data} {extract} {disable} on:select="{handleSelect}">
+<Typeahead {data} extract={(item) => item.state} disable={(item) => item.selected} on:select="{handleSelect}" />
 ```
 <!-- prettier-ignore-end -->
 
@@ -127,7 +125,7 @@ Example for disabling items after selecting them:
 | data             | `T[]` (default: `[]`)                               | Items to search                                                                                                                    |
 | extract          | `(T) => T`                                          | Target an item key if `data` is an object array                                                                                    |
 | disable          | `(T) => T`                                          | Pass in a function to disable items. They will show up in the results list, but wont be selectable.                                |
-| filter          | `(T) => T`                                           | Pass in a function to filter items. Thei will be hidden and do not show up at all in the results list.                               |
+| filter           | `(T) => T`                                          | Pass in a function to filter items. Thei will be hidden and do not show up at all in the results list.                             |
 | autoselect       | `boolean` (default: `true`)                         | Automatically select the first (top) result                                                                                        |
 | inputAfterSelect | `"update" or "clear" or "keep"`(default:`"update"`) | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` keep the search field unchanged after a selection. |
 | results          | `FuzzyResult[]` (default: `[]`)                     | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                       |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Use a slot to render custom results.
 
 Use the `filter` to filter Items out and `disable` to disable them in the result set.
 
-Excample for disabling and filtering items by their Title lenght:
+Example for disabling and filtering items by their Title lenght:
 
 <!-- prettier-ignore-start -->
 ```svelte
@@ -100,7 +100,7 @@ Excample for disabling and filtering items by their Title lenght:
 ```
 <!-- prettier-ignore-end -->
 
-Excample for disabling items after selecting them:
+Example for disabling items after selecting them:
 <!-- prettier-ignore-start -->
 ```svelte
 <script>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Use a slot to render custom results.
 
 ### Disable and Filter Items
 
-Disabling or filter items out by its Title lenght:
+Use the `filter` to filter Items out and `disable` to disable them in the result set.
+
+Excample for disabling and filtering items by their Title lenght:
+
 <!-- prettier-ignore-start -->
 ```svelte
 <script>
@@ -97,7 +100,7 @@ Disabling or filter items out by its Title lenght:
 ```
 <!-- prettier-ignore-end -->
 
-Disable selected items:
+Excample for disabling items after selecting them:
 <!-- prettier-ignore-start -->
 ```svelte
 <script>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ Use a slot to render custom results.
 ```
 <!-- prettier-ignore-end -->
 
+### Disable and Filter Items
+
+Disabling or filter items out by its Title lenght:
+<!-- prettier-ignore-start -->
+```svelte
+<script>
+    const extract = (item) => item.titel;
+    const disable = (item) => item.title.length > 4;
+    const filter = (item) => item.title.length > 8;
+</script>
+<Typeahead {data} {extract} {disable} {filter}>
+```
+<!-- prettier-ignore-end -->
+
+Disable selected items:
+<!-- prettier-ignore-start -->
+```svelte
+<script>
+   function handleSelect(e) {  
+        let i = e.detail.originalIndex;
+        data[i].selected = true;
+    }
+    
+    const extract = (item) => item.titel;
+    const disable = (item) => item.selected;
+</script>
+
+<Typeahead {data} {extract} {disable} on:select="{handleSelect}">
+```
+<!-- prettier-ignore-end -->
+
 ## API
 
 ### Props
@@ -92,6 +123,8 @@ Use a slot to render custom results.
 | value            | `string` (default: `""`)                            | Input search value                                                                                                                 |
 | data             | `T[]` (default: `[]`)                               | Items to search                                                                                                                    |
 | extract          | `(T) => T`                                          | Target an item key if `data` is an object array                                                                                    |
+| disable          | `(T) => T`                                          | Pass in a function to disable items. They will show up in the results list, but wont be selectable.                                |
+| filter          | `(T) => T`                                           | Pass in a function to filter items. Thei will be hidden and do not show up at all in the results list.                               |
 | autoselect       | `boolean` (default: `true`)                         | Automatically select the first (top) result                                                                                        |
 | inputAfterSelect | `"update" or "clear" or "keep"`(default:`"update"`) | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` keep the search field unchanged after a selection. |
 | results          | `FuzzyResult[]` (default: `[]`)                     | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                       |

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -15,6 +15,12 @@
 
   /** @type {(item: Item) => Item} */
   export let extract = (item) => item;
+  
+  /** @type {(item: Item) => Item} */
+  export let disable = (item) => item;
+  
+  /** @type {(item: Item) => Item} */
+  export let filter = (item) => false;
 
   /** Set to `false` to prevent the first result from being selected */
   export let autoselect = true;
@@ -81,7 +87,9 @@
   $: options = { pre: "<mark>", post: "</mark>", extract };
   $: results = fuzzy
     .filter(value, data, options)
-    .filter(({ score }) => score > 0);
+    .filter(({ score }) => score > 0)
+    .filter((result) => !filter(result.original))
+    .map((result)=> ({ ...result, disabled: disable(result.original)}));
   $: resultsId = results.map((result) => extract(result.original)).join("");
 </script>
 
@@ -165,10 +173,13 @@
           role="option"
           id="{id}-result"
           class:selected={selectedIndex === i}
+          class:disabled={result.disabled}
           aria-selected={selectedIndex === i}
           on:click={() => {
-            selectedIndex = i;
-            select();
+            if(!result.disabled) {
+              selectedIndex = i;
+              select();
+            } 
           }}
         >
           <slot {result} index={i}>
@@ -216,6 +227,11 @@
 
   .selected:hover {
     background-color: #cacaca;
+  }
+  
+  .disabled {
+    opacity: .4;
+    cursor: not-allowed;
   }
 
   :global([data-svelte-search] label) {

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -17,7 +17,7 @@
   export let extract = (item) => item;
   
   /** @type {(item: Item) => Item} */
-  export let disable = (item) => item;
+  export let disable = (item) => false;
   
   /** @type {(item: Item) => Item} */
   export let filter = (item) => false;

--- a/test.svelte
+++ b/test.svelte
@@ -24,10 +24,17 @@
   type Extract = (item: Item) => string;
 
   const extract: Extract = (item) => item.state;
+
+  type DisableOrFilter = (item: Item) => boolean;
+
+  const disable: DisableOrFilter = (item) => item.state.length > 10;
+  const filter: DisableOrFilter = (item) => item.state.length < 4;
 </script>
 
 <Typeahead
   {extract}
+  {disable}
+  {filter}
   autocapitalize={false + ''}
   placeholder="#{4}"
   autofocus

--- a/types/Typeahead.d.ts
+++ b/types/Typeahead.d.ts
@@ -31,16 +31,16 @@ export interface TypeaheadProps extends SearchProps {
    * @default (item) => item
    */
   extract?: (item: Item) => Item;
-  
-   /**
+
+  /**
    * @default (item) => false
    */
-  disable?: (item: Item) => false;
-  
-   /**
+  disable?: (item: Item) => boolean;
+
+  /**
    * @default (item) => false
    */
-  filter?: (item: Item) => false;
+  filter?: (item: Item) => boolean;
 
   /**
    * Set to `false` to prevent the first result from being selected

--- a/types/Typeahead.d.ts
+++ b/types/Typeahead.d.ts
@@ -31,6 +31,16 @@ export interface TypeaheadProps extends SearchProps {
    * @default (item) => item
    */
   extract?: (item: Item) => Item;
+  
+   /**
+   * @default (item) => false
+   */
+  disable?: (item: Item) => false;
+  
+   /**
+   * @default (item) => false
+   */
+  filter?: (item: Item) => false;
 
   /**
    * Set to `false` to prevent the first result from being selected


### PR DESCRIPTION
I added two options: `filter` and `disable`.

You can define functions to disable elements (they are shown, but not selectable any more) or to filter them out (they are not showing up at all).

I use this to either disable selected item or to hide them on the fly.

E.g.
```
<script>
    const extract = (item) => item.titel;
    const disable = (item) => item.title.length > 4;
    const filter = (item) => item.title.length > 8;
</script>

<Typeahead {data} {extract} {disable} {filter}>
```


```
<script>
   function handleSelect(e) {  
        let i = e.detail.originalIndex;
        data[i].selected = true;
    }
    
    const extract = (item) => item.titel;
    const disable = (item) => item.selected;
</script>

<Typeahead {data} {extract} {disable} on:select="{handleSelect}">
```