### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Example for disabling items after selecting them:
 ```
 <!-- prettier-ignore-end -->
 
+### Focus after select
+
+Set `focusAfterSelect` to `true` to re-focus the search input after selecting a result.
+
+<!-- prettier-ignore-start -->
+```svelte
+<Typeahead {data} {extract} focusAfterSelect />
+```
+<!-- prettier-ignore-end -->
+
 ## API
 
 ### Props

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -15,10 +15,10 @@
 
   /** @type {(item: Item) => Item} */
   export let extract = (item) => item;
-  
+
   /** @type {(item: Item) => Item} */
   export let disable = (item) => false;
-  
+
   /** @type {(item: Item) => Item} */
   export let filter = (item) => false;
 
@@ -89,7 +89,7 @@
     .filter(value, data, options)
     .filter(({ score }) => score > 0)
     .filter((result) => !filter(result.original))
-    .map((result)=> ({ ...result, disabled: disable(result.original)}));
+    .map((result) => ({ ...result, disabled: disable(result.original) }));
   $: resultsId = results.map((result) => extract(result.original)).join("");
 </script>
 
@@ -113,7 +113,7 @@
 >
   <Search
     {...$$restProps}
-    bind:this={searchRef}
+    bind:ref={searchRef}
     aria-autocomplete="list"
     aria-controls="{id}-listbox"
     aria-labelledby="{id}-label"
@@ -176,10 +176,10 @@
           class:disabled={result.disabled}
           aria-selected={selectedIndex === i}
           on:click={() => {
-            if(!result.disabled) {
+            if (!result.disabled) {
               selectedIndex = i;
               select();
-            } 
+            }
           }}
         >
           <slot {result} index={i}>
@@ -228,9 +228,9 @@
   .selected:hover {
     background-color: #cacaca;
   }
-  
+
   .disabled {
-    opacity: .4;
+    opacity: 0.4;
     cursor: not-allowed;
   }
 

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -118,7 +118,6 @@
     aria-controls="{id}-listbox"
     aria-labelledby="{id}-label"
     aria-activedescendant=""
-    {id}
     bind:value
     on:type
     on:input


### PR DESCRIPTION
**Fixes**

- bind the input element reference correctly to fix focusing behavior, fixes #11
- don't pass the Typeahead id to Search, fixes #10 