### PR TITLE
Export SearchRef for focusing

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -44,7 +44,7 @@
   const dispatch = createEventDispatcher();
 
   let comboboxRef = null;
-  let searchRef = null;
+  export let searchRef = null;
   let hideDropdown = false;
   let selectedIndex = -1;
   let prevResults = "";
@@ -69,6 +69,12 @@
     if (inputAfterSelect == "clear") value = "";
     if (inputAfterSelect == "update") value = selectedValue;
 
+    await tick();
+
+    if (focusAfterSelect) searchRef.focus();
+
+    hideDropdown = true;
+    
     dispatch("select", {
       selectedIndex,
       searched: searchedValue,
@@ -77,11 +83,6 @@
       originalIndex: result.index,
     });
 
-    await tick();
-
-    if (focusAfterSelect) searchRef.focus();
-
-    hideDropdown = true;
   }
 
   $: options = { pre: "<mark>", post: "</mark>", extract };


### PR DESCRIPTION
I formerly said I could call `this.focus()` from outside. That was wrong and I do not know in what state my code was then that it had worked.

So this pr adds up on https://github.com/metonym/svelte-typeahead/issues/11. To keep the behavior as it is it would be great for me to be able to focus from outside.

Also the `select` event had to be dispatched after the dropdown is closed, therefore I moved it to the end of the function.

If you dont mind I would be happy to see this code merged, otherwise I`ll just keep it for myself. :)

The only downside is, that I have to set `focusAfterSelect` to `false` to be able to actually focus after select. If I keep it to true the focus event wouldn't trigger the focus event.