### PR TITLE
Consistent id's with svelte-search

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -175,6 +175,7 @@
   />
   {#if !hideDropdown && results.length > 0}
     <ul
+      class:svelte-typeahead-list={true}
       role="listbox"
       aria-labelledby="{id}-label"
       id="{id}-listbox"

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -121,9 +121,10 @@
   aria-owns="{id}-listbox"
   class:dropdown={results.length > 0}
   aria-expanded={!hideDropdown && results.length > 0}
-  {id}
+  id="{id}-typeahead"
 >
   <Search
+    {id}
     {...$$restProps}
     bind:ref={searchRef}
     aria-autocomplete="list"
@@ -174,15 +175,14 @@
   />
   {#if !hideDropdown && results.length > 0}
     <ul
-      class:svelte-typeahead-list={true}
       role="listbox"
-      aria-labelledby=""
+      aria-labelledby="{id}-label"
       id="{id}-listbox"
     >
       {#each results as result, i}
         <li
           role="option"
-          id="{id}-result"
+          id="{id}-result-{i}"
           class:selected={selectedIndex === i}
           class:disabled={result.disabled}
           aria-selected={selectedIndex === i}


### PR DESCRIPTION
Pass Typeahead's id property to Search to ensure proper `aria-labelledby` references. 
Updated Typeahead wrapper div id to not clash with Search's input id (this feels slightly hackish to me, but avoids separate PRs to Search).

Removed an unreferenced (and oddly defined?) CSS class, updated an inner aria-labelledby reference (this is honestly a guess, as I'm not exactly an aria expert...) and ensured unique id's on the result list items.