### PR TITLE
feat: add "no-results" slot if value does not yield results

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Use a slot to render custom results.
 </Typeahead>
 ```
 
+### No results
+
+Use the "no-results" slot to render a message if the search value does not yield results.
+
+```svelte
+<Typeahead {data} {extract} let:value>
+  <svelte:fragment slot="no-results">
+    No results found for "{value}"
+  </svelte:fragment>
+</Typeahead>
+```
+
 ### Limit the number of results
 
 Use the `limit` prop to specify the maximum number of results to display. The default limit is `Infinity`.

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -60,7 +60,7 @@
       selectedIndex = 0;
     }
 
-    if (prevResults !== resultsId) {
+    if (prevResults !== resultsId && !$$slots["no-results"]) {
       hideDropdown = results.length === 0;
     }
 
@@ -102,12 +102,7 @@
 
 <svelte:window
   on:click={({ target }) => {
-    if (
-      !hideDropdown &&
-      results.length > 0 &&
-      comboboxRef &&
-      !comboboxRef.contains(target)
-    ) {
+    if (!hideDropdown && comboboxRef && !comboboxRef.contains(target)) {
       hideDropdown = true;
     }
   }}
@@ -151,6 +146,8 @@
     on:blur
     on:keydown
     on:keydown={(e) => {
+      if (results.length === 0) return;
+
       switch (e.key) {
         case "Enter":
           select();
@@ -199,11 +196,16 @@
             }
           }}
         >
-          <slot {result} index={i}>
+          <slot {result} index={i} {value}>
             {@html result.string}
           </slot>
         </li>
       {/each}
+    {/if}
+    {#if $$slots["no-results"] && !hideDropdown && value.length > 0 && results.length === 0}
+      <div class:no-results={true}>
+        <slot name="no-results" {value} />
+      </div>
     {/if}
   </ul>
 </div>
@@ -225,8 +227,12 @@
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }
 
-  li {
+  li,
+  .no-results {
     padding: 0.25rem 1rem;
+  }
+
+  li {
     cursor: pointer;
   }
 

--- a/test/Typeahead.test.svelte
+++ b/test/Typeahead.test.svelte
@@ -56,10 +56,15 @@
   bind:results
   let:result
   let:index
+  let:value={searchedValue}
 >
   {@html result.string}
   {index}
   {result.score}
+  {searchedValue}
+  <svelte:fragment slot="no-results" let:value>
+    No results {value}
+  </svelte:fragment>
 </Typeahead>
 
 <!-- svelte-ignore missing-declaration -->

--- a/types/Typeahead.svelte.d.ts
+++ b/types/Typeahead.svelte.d.ts
@@ -94,6 +94,10 @@ export default class Typeahead extends SvelteComponentTyped<
     default: {
       result: FuzzyResult;
       index: number;
+      value: string;
+    };
+    "no-results": {
+      value: string;
     };
   }
 > {}


### PR DESCRIPTION
Related #30, #27

**Features**

- render a "no-results" slot when the search value does not yield results
- add `value` to the default slot props