### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies and build the library
+        run: |
+          yarn
+          yarn prepack
+      - name: Validate the TypeScript definitions
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ yarn add -D svelte-typeahead
 npm i -D svelte-typeahead
 ```
 
+**pnpm**
+
+```bash
+pnpm i -D svelte-typeahead
+```
+
 ## Usage
 
 ### SvelteKit set-up

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export default config;
 
 ### Basic
 
-Pass an array of objects to the `data` prop. Use the `extractor` to specify the key value to search on.
+Pass an array of objects to the `data` prop. Use the `extractor` prop to specify the value to search on.
 
 ```svelte
 <script>
@@ -122,7 +122,7 @@ Use the "no-results" slot to render a message if the search value does not yield
 
 ### Limit the number of results
 
-Use the `limit` prop to specify the maximum number of results to display. The default limit is `Infinity`.
+Use the `limit` prop to specify the maximum number of results to display. The default is `Infinity`.
 
 ```svelte
 <Typeahead limit={2} {data} {extract} />
@@ -135,13 +135,12 @@ Disable items using the `disable` filter.
 In the following example, items with a `state` value containing "Carolina" are disabled. Disabled items are not selectable nor keyboard navigable.
 
 ```svelte
-<script>
-  import Typeahead from "svelte-typeahead";
-
-  const disable = (item) => /Carolina/.test(item.state);
-</script>
-
-<Typeahead value="ca" {data} {extract} {disable} />
+<Typeahead
+  {data}
+  value="ca"
+  extract={(item) => item.state}
+  disable={(item) => /Carolina/.test(item.state)}
+/>
 ```
 
 Example for disabling items after selecting them:

--- a/README.md
+++ b/README.md
@@ -122,21 +122,20 @@ Use the `limit` prop to specify the maximum number of results to display. The de
 <Typeahead limit={2} {data} {extract} />
 ```
 
-### Disable and filter items
+### Disabled items
 
-Use the `filter` to filter Items out and `disable` to disable them in the result set.
+Disable items using the `disable` filter.
 
-Example for disabling and filtering items by their title length:
+In the following example, items with a `state` value containing "Carolina" are disabled. Disabled items are not selectable nor keyboard navigable.
 
 ```svelte
 <script>
   import Typeahead from "svelte-typeahead";
 
-  const disable = (item) => item.state.length > 4;
-  const filter = (item) => item.state.length > 8;
+  const disable = (item) => /Carolina/.test(item.state);
 </script>
 
-<Typeahead {data} extract={(item) => item.state} {disable} {filter} />
+<Typeahead value="ca" {data} {extract} {disable} />
 ```
 
 Example for disabling items after selecting them:

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -27,7 +27,7 @@
    */
   export let inputAfterSelect = "update";
 
-  /** @type {{ original: TItem; index: number; score: number; string: string; }[]} */
+  /** @type {{ original: TItem; index: number; score: number; string: string; disabled?: boolean; }[]} */
   export let results = [];
 
   /** Set to `true` to re-focus the input after selecting a result */

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -65,6 +65,9 @@
 
   async function select() {
     const result = results[selectedIndex];
+
+    if (result.disabled) return;
+
     const selectedValue = extract(result.original);
     const searchedValue = value;
 

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -89,6 +89,27 @@
     hideDropdown = true;
   }
 
+  /** @type {(direction: -1 | 1) => void} */
+  function change(direction) {
+    let index =
+      selectedIndex === results.length - 1 ? 0 : selectedIndex + direction;
+    if (index < 0) index = results.length - 1;
+
+    let disabled = results[index].disabled;
+
+    while (disabled) {
+      if (index === results.length) {
+        index = 0;
+      } else {
+        index += direction;
+      }
+
+      disabled = results[index].disabled;
+    }
+
+    selectedIndex = index;
+  }
+
   $: options = { pre: "<mark>", post: "</mark>", extract };
   $: results = fuzzy
     .filter(value, data, options)
@@ -153,17 +174,11 @@
           break;
         case "ArrowDown":
           e.preventDefault();
-          selectedIndex += 1;
-          if (selectedIndex === results.length) {
-            selectedIndex = 0;
-          }
+          change(1);
           break;
         case "ArrowUp":
           e.preventDefault();
-          selectedIndex -= 1;
-          if (selectedIndex < 0) {
-            selectedIndex = results.length - 1;
-          }
+          change(-1);
           break;
         case "Escape":
           e.preventDefault();

--- a/test/Typeahead.test.svelte
+++ b/test/Typeahead.test.svelte
@@ -5,6 +5,8 @@
 
   let results: TypeaheadProps<typeof data[0]>["results"] = [];
 
+  $: console.log(results[0]?.disabled);
+
   const data = [
     { id: 0, state: "California" },
     { id: 1, state: "North Carolina" },

--- a/types/Typeahead.svelte.d.ts
+++ b/types/Typeahead.svelte.d.ts
@@ -53,6 +53,7 @@ export interface TypeaheadProps<TItem> extends SearchProps {
     index: number;
     score: number;
     string: string;
+    disabled?: boolean;
   }[];
 
   /**


### PR DESCRIPTION
**Fixes**

- prevent keyboard selection and navigation of disabled results (fixes #34)
- add missing annotation for `TItem.disabled` to `results` prop (fixes #35)

**Documentation**

- add `pnpm` installation command
