### PR TITLE
Docs audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ const config = {
     },
   },
 };
-
-export default config;
 ```
 
 ### Styling

--- a/README.md
+++ b/README.md
@@ -143,19 +143,6 @@ In the following example, items with a `state` value containing "Carolina" are d
 />
 ```
 
-Example for disabling items after selecting them:
-
-```svelte
-<Typeahead
-  {data}
-  extract={(item) => item.state}
-  disable={(item) => item.selected}
-  on:select={({ detail }) => {
-    data[detail.originalIndex].selected = true;
-  }}
-/>
-```
-
 ### Focus after select
 
 Set `focusAfterSelect` to `true` to re-focus the search input after selecting a result.

--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ Pass an array of objects to the `data` prop. Use the `extractor` prop to specify
   import Typeahead from "svelte-typeahead";
 
   const data = [
-    { id: 0, state: "California" },
-    { id: 1, state: "North Carolina" },
-    { id: 2, state: "North Dakota" },
-    { id: 3, state: "South Carolina" },
-    { id: 4, state: "South Dakota" },
-    { id: 5, state: "Michigan" },
-    { id: 6, state: "Tennessee" },
-    { id: 7, state: "Nevada" },
-    { id: 8, state: "New Hampshire" },
-    { id: 9, state: "New Jersey" },
+    { state: "California" },
+    { state: "North Carolina" },
+    { state: "North Dakota" },
+    { state: "South Carolina" },
+    { state: "South Dakota" },
+    { state: "Michigan" },
+    { state: "Tennessee" },
+    { state: "Nevada" },
+    { state: "New Hampshire" },
+    { state: "New Jersey" },
   ];
 
   const extract = (item) => item.state;
@@ -95,9 +95,9 @@ Pass an array of objects to the `data` prop. Use the `extractor` prop to specify
 
 ### Custom-styled results
 
-By default, this component uses the `fuzzy` library to highlight matching characters with the `mark` element.
+This component uses the `fuzzy` library to highlight matching characters with the `mark` element.
 
-Use a slot to render custom results.
+Override the default slot to render custom results.
 
 ```svelte
 <Typeahead {data} {extract} let:result let:index>
@@ -161,7 +161,7 @@ Set `focusAfterSelect` to `true` to re-focus the search input after selecting a 
 | data             | `T[]` (default: `[]`)                               | Items to search                                                                                                                    |
 | extract          | `(T) => T`                                          | Target an item key if `data` is an object array                                                                                    |
 | disable          | `(T) => T`                                          | Pass in a function to disable items. They will show up in the results list, but wont be selectable.                                |
-| filter           | `(T) => T`                                          | Pass in a function to filter items. Thei will be hidden and do not show up at all in the results list.                             |
+| filter           | `(T) => T`                                          | Pass in a function to filter items. They will be hidden and do not show up at all in the results list.                             |
 | autoselect       | `boolean` (default: `true`)                         | Automatically select the first (top) result                                                                                        |
 | inputAfterSelect | `"update" or "clear" or "keep"`(default:`"update"`) | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` keep the search field unchanged after a selection. |
 | results          | `FuzzyResult[]` (default: `[]`)                     | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                       |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Override the default slot to render custom results.
 Use the "no-results" slot to render a message if the search value does not yield results.
 
 ```svelte
-<Typeahead {data} {extract} let:value>
+<Typeahead value="abcd" {data} {extract} let:value>
   <svelte:fragment slot="no-results">
     No results found for "{value}"
   </svelte:fragment>
@@ -155,19 +155,19 @@ Set `focusAfterSelect` to `true` to re-focus the search input after selecting a 
 
 ### Props
 
-| Prop name        | Value                                               | Description                                                                                                                        |
-| :--------------- | :-------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
-| value            | `string` (default: `""`)                            | Input search value                                                                                                                 |
-| data             | `T[]` (default: `[]`)                               | Items to search                                                                                                                    |
-| extract          | `(T) => T`                                          | Target an item key if `data` is an object array                                                                                    |
-| disable          | `(T) => T`                                          | Pass in a function to disable items. They will show up in the results list, but wont be selectable.                                |
-| filter           | `(T) => T`                                          | Pass in a function to filter items. They will be hidden and do not show up at all in the results list.                             |
-| autoselect       | `boolean` (default: `true`)                         | Automatically select the first (top) result                                                                                        |
-| inputAfterSelect | `"update" or "clear" or "keep"`(default:`"update"`) | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` keep the search field unchanged after a selection. |
-| results          | `FuzzyResult[]` (default: `[]`)                     | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                       |
-| focusAfterSelect | `boolean` (default: `false`)                        | Set to `true` to re-focus the input after selecting a result.                                                                      |
-| limit            | `number` (default: `Infinity`)                      | Specify the maximum number of results to return                                                                                    |
-| `...$$restProps` | (forwarded to `Search` component)                   | All other props are forwarded to the input element.                                                                                |
+| Prop name        | Value                                                                      | Description                                                                                                                           |
+| :--------------- | :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| value            | `string` (default: `""`)                                                   | Input search value                                                                                                                    |
+| data             | `TItem[]` (default: `[]`)                                                  | Items to search                                                                                                                       |
+| extract          | `(TItem) => any`                                                           | Target an item key if `data` is an object array                                                                                       |
+| disable          | `(TItem) => boolean`                                                       | Pass in a function to disable items. They can be displayed in the results but will not be selectable.                                 |
+| filter           | `(TItem) => boolean`                                                       | Pass in a function to filter items. They will be hidden and are not displayed in the results.                                         |
+| autoselect       | `boolean` (default: `true`)                                                | Automatically select the first (top) result                                                                                           |
+| inputAfterSelect | `"update" or "clear" or "keep"`(default: `"update"`)                       | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` to keep the search field unchanged after a selection. |
+| results          | `FuzzyResult[]` (default: `[]`)                                            | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                          |
+| focusAfterSelect | `boolean` (default: `false`)                                               | Set to `true` to re-focus the input after selecting a result.                                                                         |
+| limit            | `number` (default: `Infinity`)                                             | Specify the maximum number of results to display.                                                                                     |
+| `...$$restProps` | (forwarded to [`svelte-search`](https://github.com/metonym/svelte-search)) | All other props are forwarded to the input element.                                                                                   |
 
 ### Dispatched events
 
@@ -178,21 +178,19 @@ Set `focusAfterSelect` to `true` to re-focus the search input after selecting a 
 <script>
   import Typeahead from "svelte-typeahead";
 
-  let events = [];
-
-  const update = (event, detail) => (events = [...events, { event, detail }]);
+  let e = [];
 </script>
 
 <Typeahead
   {data}
   {extract}
-  on:select={(e) => update("select", e.detail)}
-  on:clear={() => update("clear")}
+  on:select={({ detail }) => (e = [...e, { event: "select", detail }])}
+  on:clear={() => (e = [...e, { event: "clear" }])}
 />
 
-{#each events as event}
-  <pre>{JSON.stringify(event, null, 2)}</pre>
-{/each}
+<pre>
+  {JSON.stringify(e, null, 2)}
+</pre>
 ```
 
 ### Forwarded events


### PR DESCRIPTION
Closes #36

**Documentation**

- remove "disabling items after selection" example
- remove `id` fields from `data` array
- simplify dispatched events example