### PR TITLE
fix(typeahead): hover should update the selected index

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -209,6 +209,10 @@
               select();
             }
           }}
+          on:mouseenter={() => {
+            if (result.disabled) return;
+            selectedIndex = i;
+          }}
         >
           <slot {result} index={i} {value}>
             {@html result.string}


### PR DESCRIPTION
Hovering over a result item should update the selected index.

For example, the first result is highlighted by default. However, if I hover over the third result and press "Enter," the third result should be selected. Using keyboard navigation should also start the navigation at the hovered index.