### PR TITLE
fix: allow results to be selected if using `showDropdownOnFocus`

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -188,14 +188,14 @@
     on:focus
     on:focus={() => {
       open();
-      isFocused = true;
+      if (showDropdownOnFocus) {
+        showResults = true;
+        isFocused = true;
+      }
     }}
     on:clear
     on:clear={open}
     on:blur
-    on:blur={() => {
-      isFocused = false;
-    }}
     on:keydown
     on:keydown={(e) => {
       if (results.length === 0) return;


### PR DESCRIPTION
Related #54, #55

Currently, if using `showDropdownOnFocus`, results cannot be clicked since the `on:blur` handler fires before a click event can be registered.