### PR TITLE
feat: add `showAllResultsOnFocus` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,24 +169,35 @@ Set `showDropdownOnFocus` to `true` to only show the dropdown when the search in
 <Typeahead value="ca" showDropdownOnFocus {data} {extract} />
 ```
 
+### Show all results on focus
+
+By default, no results are shown if an empty input (i.e., `value=""`) is focused.
+
+Set `showAllResultsOnFocus` to `true` for all results to be shown when an empty input is focused.
+
+```svelte
+<Typeahead showAllResultsOnFocus {data} {extract} />
+```
+
 ## API
 
 ### Props
 
-| Prop name           | Value                                                                      | Description                                                                                                                           |
-| :------------------ | :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| value               | `string` (default: `""`)                                                   | Input search value                                                                                                                    |
-| data                | `TItem[]` (default: `[]`)                                                  | Items to search                                                                                                                       |
-| extract             | `(TItem) => any`                                                           | Target an item key if `data` is an object array                                                                                       |
-| disable             | `(TItem) => boolean`                                                       | Pass in a function to disable items. They can be displayed in the results but will not be selectable.                                 |
-| filter              | `(TItem) => boolean`                                                       | Pass in a function to filter items. They will be hidden and are not displayed in the results.                                         |
-| autoselect          | `boolean` (default: `true`)                                                | Automatically select the first (top) result                                                                                           |
-| inputAfterSelect    | `"update" or "clear" or "keep"`(default: `"update"`)                       | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` to keep the search field unchanged after a selection. |
-| results             | `FuzzyResult[]` (default: `[]`)                                            | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                          |
-| focusAfterSelect    | `boolean` (default: `false`)                                               | Set to `true` to re-focus the input after selecting a result.                                                                         |
-| showDropdownOnFocus | `boolean` (default: `false`)                                               | Set to `true` to only show results when the input is focused.                                                                         |
-| limit               | `number` (default: `Infinity`)                                             | Specify the maximum number of results to display.                                                                                     |
-| `...$$restProps`    | (forwarded to [`svelte-search`](https://github.com/metonym/svelte-search)) | All other props are forwarded to the input element.                                                                                   |
+| Prop name             | Value                                                                      | Description                                                                                                                           |
+| :-------------------- | :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| value                 | `string` (default: `""`)                                                   | Input search value                                                                                                                    |
+| data                  | `TItem[]` (default: `[]`)                                                  | Items to search                                                                                                                       |
+| extract               | `(TItem) => any`                                                           | Target an item key if `data` is an object array                                                                                       |
+| disable               | `(TItem) => boolean`                                                       | Pass in a function to disable items. They can be displayed in the results but will not be selectable.                                 |
+| filter                | `(TItem) => boolean`                                                       | Pass in a function to filter items. They will be hidden and are not displayed in the results.                                         |
+| autoselect            | `boolean` (default: `true`)                                                | Automatically select the first (top) result                                                                                           |
+| inputAfterSelect      | `"update" or "clear" or "keep"`(default: `"update"`)                       | Set to `"clear"` to clear the `value` after selecting a result. Set to `"keep"` to keep the search field unchanged after a selection. |
+| results               | `FuzzyResult[]` (default: `[]`)                                            | Raw fuzzy results from the [fuzzy](https://github.com/mattyork/fuzzy) module                                                          |
+| focusAfterSelect      | `boolean` (default: `false`)                                               | Set to `true` to re-focus the input after selecting a result.                                                                         |
+| showDropdownOnFocus   | `boolean` (default: `false`)                                               | Set to `true` to only show results when the input is focused.                                                                         |
+| showAllResultsOnFocus | `boolean` (default: `false`)                                               | Set to `true` for all results to be shown when an empty input is focused.                                                             |
+| limit                 | `number` (default: `Infinity`)                                             | Specify the maximum number of results to display.                                                                                     |
+| `...$$restProps`      | (forwarded to [`svelte-search`](https://github.com/metonym/svelte-search)) | All other props are forwarded to the input element.                                                                                   |
 
 ### Dispatched events
 

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -36,6 +36,9 @@
   /** Set to `true` to only show results when the input is focused */
   export let showDropdownOnFocus = false;
 
+  /** Set to `true` for all results to be shown when an empty input is focused */
+  export let showAllResultsOnFocus = false;
+
   /**
    * Specify the maximum number of results to return
    * @type {number}
@@ -134,7 +137,10 @@
   }
 
   const open = () => (hideDropdown = false);
-  const close = () => (hideDropdown = true);
+  const close = () => {
+    hideDropdown = true;
+    isFocused = false;
+  };
 
   $: options = { pre: "<mark>", post: "</mark>", extract };
   $: results = fuzzy
@@ -147,6 +153,17 @@
   $: showResults = !hideDropdown && results.length > 0;
   $: if (showDropdownOnFocus) {
     showResults = showResults && isFocused;
+  }
+  $: if (isFocused && showAllResultsOnFocus && value.length === 0) {
+    results = data
+      .filter((datum) => !filter(datum))
+      .map((original, index) => ({
+        disabled: disable(original),
+        index,
+        original,
+        score: 0,
+        string: extract(original),
+      }));
   }
 </script>
 
@@ -188,7 +205,7 @@
     on:focus
     on:focus={() => {
       open();
-      if (showDropdownOnFocus) {
+      if (showDropdownOnFocus || showAllResultsOnFocus) {
         showResults = true;
         isFocused = true;
       }

--- a/test/Typeahead.test.svelte
+++ b/test/Typeahead.test.svelte
@@ -34,6 +34,7 @@
   focusAfterSelect
   inputAfterSelect="keep"
   debounce={800}
+  showAllResultsOnFocus
   {data}
   on:select={(e) => {
     console.log("select", e.detail);

--- a/types/Typeahead.svelte.d.ts
+++ b/types/Typeahead.svelte.d.ts
@@ -69,6 +69,12 @@ export interface TypeaheadProps<TItem> extends SearchProps {
   showDropdownOnFocus?: boolean;
 
   /**
+   * Set to `true` for all results to be shown when an empty input is focused
+   * @default false
+   */
+  showAllResultsOnFocus?: boolean;
+
+  /**
    * Specify the maximum number of results to return
    * @default Infinity
    */


### PR DESCRIPTION
Closes #64

By default, no results are shown if an empty input (i.e., `value=""`) is focused.

This adds a `showAllResultsOnFocus` prop that – if enabled – displays all results when an empty input is shown.

```svelte
<Typeahead showAllResultsOnFocus {data} {extract} />
```