### PR TITLE
fix(style): unset `ul` margin

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -287,6 +287,7 @@
     top: 100%;
     left: 0;
     width: 100%;
+    margin: 0;
     padding: 0;
     list-style: none;
     background-color: inherit;


### PR DESCRIPTION
`ul` elements typically have a default margin value that should be unset.