### PR TITLE
fix(types): `clear` event detail should be `null`

### DIFF
--- a/types/Typeahead.svelte.d.ts
+++ b/types/Typeahead.svelte.d.ts
@@ -94,7 +94,7 @@ export default class Typeahead<
       originalIndex: number;
     }>;
     type: CustomEvent<string>;
-    clear: CustomEvent<any>;
+    clear: CustomEvent<null>;
     input: WindowEventMap["input"];
     change: WindowEventMap["change"];
     focus: WindowEventMap["focus"];


### PR DESCRIPTION
Narrow the event type from `any` to `null`.