### PR TITLE
fix(a11y): silence a11y warnings in Svelte@3.52

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",
-    "svelte": "^3.49.0",
+    "svelte": "^3.52.0",
     "svelte-check": "^2.9.0",
     "svelte-readme": "^3.6.3"
   },

--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -175,6 +175,7 @@
   }}
 />
 
+<!-- svelte-ignore a11y-role-has-required-aria-props -->
 <div
   data-svelte-typeahead
   bind:this={comboboxRef}
@@ -246,6 +247,7 @@
   >
     {#if showResults}
       {#each results as result, index}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
         <li
           role="option"
           id="{id}-result-{index}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,10 +939,10 @@ svelte-search@^1.1.0:
   resolved "https://registry.yarnpkg.com/svelte-search/-/svelte-search-1.1.0.tgz#c41cc089a6a15d40911912d7ce497e6ae49d2150"
   integrity sha512-e5hci9fZPMXb3fuRZvcYJGqh448M8vV3biY4lN4Nr9fqrG/HBnTjWYstKb399aUe9tsBxRbxRAWgtKicisL23g==
 
-svelte@^3.49.0:
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
-  integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
+svelte@^3.52.0:
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.52.0.tgz#08259eff20904c63882b66a5d409a55e8c6743b8"
+  integrity sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==
 
 terser@^5.0.0:
   version "5.14.2"


### PR DESCRIPTION
Fixes #66

`svelte-ignore a11y-role-has-required-aria-props` should be investigated more deeply, which calls for adding an `aria-controls` attribute to the element.

`svelte-ignore a11y-click-events-have-key-events` can be ignored since key events are attached to the underlying `input` element.