### PR TITLE
fix(a11y): resolve `a11y-role-has-required-aria-props` warning

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -175,13 +175,12 @@
   }}
 />
 
-<!-- svelte-ignore a11y-role-has-required-aria-props -->
 <div
   data-svelte-typeahead
   bind:this={comboboxRef}
   role="combobox"
   aria-haspopup="listbox"
-  aria-owns="{id}-listbox"
+  aria-controls="{id}-listbox"
   class:dropdown={results.length > 0}
   aria-expanded={showResults}
   id="{id}-typeahead"


### PR DESCRIPTION
Fixes #72

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role), `aria-owns` should be changed to `aria-controls`, which resolves the a11y warning.