### PR TITLE
fix: close dropdown for keyboard navigation

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -212,7 +212,15 @@
     }}
     on:clear
     on:clear={open}
-    on:blur
+    on:blur={(e) => {
+      // Check if focus is moving to an element within the combobox
+      const relatedTarget = e.relatedTarget;
+      if (relatedTarget && comboboxRef?.contains(relatedTarget)) {
+        return;
+      }
+      // Close immediately for keyboard navigation (Tab, Shift+Tab)
+      close();
+    }}
     on:keydown
     on:keydown={(e) => {
       if (results.length === 0) return;
@@ -253,8 +261,9 @@
           class:selected={selectedIndex === index}
           class:disabled={result.disabled}
           aria-selected={selectedIndex === index}
-          on:click={() => {
+          on:mousedown={(e) => {
             if (result.disabled) return;
+            e.preventDefault(); // Prevent input from losing focus
             selectedIndex = index;
             select();
           }}


### PR DESCRIPTION
Fixes #95

This fixes the dropdown not closing when input loses focus via keyboard navigation. This causes overlapping dropdowns and renders the page unusable when `showAllResultsOnFocus` is enabled.

**Changes**

- Change result item selection from `click` to `mousedown` with `preventDefault()` to prevent the input from losing focus when clicking results. This ensures the blur handler only fires for legitimate focus loss (e.g., tab navigation) rather than result selection.