### PR TITLE
fix: only show dropdown when focusing input

### DIFF
--- a/src/Typeahead.svelte
+++ b/src/Typeahead.svelte
@@ -33,7 +33,10 @@
   /** Set to `true` to re-focus the input after selecting a result */
   export let focusAfterSelect = false;
 
-  /** Set to `true` to only show results when the input is focused */
+  /**
+   * Set to `true` to only show results when the input is focused
+   * @deprecated Focus is now always required to show results. This prop has no effect and will be removed in a future version.
+   */
   export let showDropdownOnFocus = false;
 
   /** Set to `true` for all results to be shown when an empty input is focused */
@@ -150,10 +153,7 @@
     .filter((result) => !filter(result.original))
     .map((result) => ({ ...result, disabled: disable(result.original) }));
   $: resultsId = results.map((result) => extract(result.original)).join("");
-  $: showResults = !hideDropdown && results.length > 0;
-  $: if (showDropdownOnFocus) {
-    showResults = showResults && isFocused;
-  }
+  $: showResults = !hideDropdown && results.length > 0 && isFocused;
   $: if (isFocused && showAllResultsOnFocus && value.length === 0) {
     results = data
       .filter((datum) => !filter(datum))
@@ -205,9 +205,9 @@
     on:focus
     on:focus={() => {
       open();
+      isFocused = true;
       if (showDropdownOnFocus || showAllResultsOnFocus) {
         showResults = true;
-        isFocused = true;
       }
     }}
     on:clear


### PR DESCRIPTION
Fixes #99

Currently, Typeahead results would display even when the input field doesn't have focus (reacting to `value` changes). This was particularly problematic in scenarios with dependent Typeahead components where values are set programmatically. When a parent Typeahead selection automatically populated a child Typeahead with a single matching result, that result would incorrectly display even though the user hadn't interacted with the child input.

From a UX standpoint, it makes sense to only show results when the current input is focused. This, however, renders the current `showDropdownOnFocus` a no-op. It may need to be inverted (e.g., show menu if input has value).

```svelte
// Before: results could show without focus
$: showResults = !hideDropdown && results.length > 0;
$: if (showDropdownOnFocus) {
  showResults = showResults && isFocused;
}

// After: results always require focus
$: showResults = !hideDropdown && results.length > 0 && isFocused;
```

This ensures results only appear when users are actively interacting with the input, preventing unwanted dropdown displays in programmatic usage scenarios.